### PR TITLE
Fixed case where drawer side controller is nil

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -655,6 +655,12 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
                 
                 [self.centerContainerView setCenter:CGPointMake(CGRectGetMidX(newFrame), CGRectGetMidY(newFrame))];
             }
+            else{
+                CGRect noneSideFrame;
+                noneSideFrame.size = newFrame.size;
+                noneSideFrame.origin = CGPointMake(0.f, newFrame.origin.y);
+                [self.centerContainerView setFrame:noneSideFrame];
+            }
             break;
         }
         case UIGestureRecognizerStateCancelled:


### PR DESCRIPTION
What'chu think, dawg?

When the drawer is nil and the user tries to pan in that direction, I've changed it so that the drawer side is properly set to `MMDrawerSideNone`. I've also added a block to prevent panning in that direction at all. I believe this is the most expected functionality.
