### PR TITLE
You shouldn't be able to bounce a drawer if it is nil

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -386,7 +386,10 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 
 -(void)bouncePreviewForDrawerSide:(MMDrawerSide)drawerSide distance:(CGFloat)distance completion:(void(^)(BOOL finished))completion{
     NSParameterAssert(drawerSide!=MMDrawerSideNone);
-    if(self.openSide != MMDrawerSideNone){
+    
+    UIViewController * sideDrawerViewController = [self sideDrawerViewControllerForSide:drawerSide];
+    
+    if(sideDrawerViewController == nil){
         if(completion){
             completion(NO);
         }


### PR DESCRIPTION
Fixed a bug where you could still bounce the drawer even if there was no sideDrawerController for that side.

@larsacus let me handle merging it back in to coordinate with another version bump. Just looking for your approval here.
