### PR TITLE
Additional parameters for drawer paddings

### DIFF
--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -131,6 +131,20 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
 @property (nonatomic, assign) CGFloat maximumRightDrawerWidth;
 
 /**
+ The width padding of the left `leftDrawerViewController`
+ 
+ By default, this is set to 0. but can be increase to let rounded corners be covered by the drawer background color
+ */
+@property (nonatomic, assign) CGFloat leftDrawerWidthPadding;
+
+/**
+ The width padding of the left `rightDrawerViewController`
+ 
+ By default, this is set to 0. but can be increase to let rounded corners be covered by the drawer background color
+ */
+@property (nonatomic, assign) CGFloat rightDrawerWidthPadding;
+
+/**
  The visible width of the `leftDrawerViewController`. 
  
  Note this value can be greater than `maximumLeftDrawerWidth` during the full close animation when setting a new center view controller;

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -137,6 +137,9 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
         [self setMaximumLeftDrawerWidth:MMDrawerDefaultWidth];
         [self setMaximumRightDrawerWidth:MMDrawerDefaultWidth];
         
+        [self setLeftDrawerWidthPadding:0];
+        [self setRightDrawerWidthPadding:0];
+        
         [self setAnimationVelocity:MMDrawerDefaultAnimationVelocity];
         
         [self setShowsShadow:YES];

--- a/MMDrawerController/UIViewController+MMDrawerController.m
+++ b/MMDrawerController/UIViewController+MMDrawerController.m
@@ -41,14 +41,14 @@
     if([self isEqual:self.mm_drawerController.leftDrawerViewController] ||
        [self.navigationController isEqual:self.mm_drawerController.leftDrawerViewController]){
         CGRect rect = self.mm_drawerController.view.bounds;
-        rect.size.width = self.mm_drawerController.maximumLeftDrawerWidth;
+        rect.size.width = self.mm_drawerController.maximumLeftDrawerWidth + self.mm_drawerController.leftDrawerWidthPadding;
         return rect;
         
     }
     else if([self isEqual:self.mm_drawerController.rightDrawerViewController] ||
              [self.navigationController isEqual:self.mm_drawerController.rightDrawerViewController]){
         CGRect rect = self.mm_drawerController.view.bounds;
-        rect.size.width = self.mm_drawerController.maximumRightDrawerWidth;
+        rect.size.width = self.mm_drawerController.maximumRightDrawerWidth + self.mm_drawerController.rightDrawerWidthPadding;
         rect.origin.x = CGRectGetWidth(self.mm_drawerController.view.bounds)-rect.size.width;
         return rect;
     }


### PR DESCRIPTION
Let us make the drawer controllers a little bit bigger than the `maximumLeftDrawerWidth` to cover round corners of a central controller for instance with the background of the drawer.
