### PR TITLE
Initialization refactoring & improvements

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -128,6 +128,27 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 
 @implementation MMDrawerController
 
+#pragma mark - Init
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+	if (self) {
+		[self setMaximumLeftDrawerWidth:MMDrawerDefaultWidth];
+		[self setMaximumRightDrawerWidth:MMDrawerDefaultWidth];
+
+		[self setAnimationVelocity:MMDrawerDefaultAnimationVelocity];
+
+		[self setShowsShadow:YES];
+		[self setShouldStretchDrawer:YES];
+
+		[self setOpenDrawerGestureModeMask:MMOpenDrawerGestureModeNone];
+		[self setCloseDrawerGestureModeMask:MMCloseDrawerGestureModeNone];
+		[self setCenterHiddenInteractionMode:MMDrawerOpenCenterInteractionModeNavigationBarOnly];
+	}
+
+	return self;
+}
+
 -(id)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
     NSParameterAssert(centerViewController);
     self = [self init];
@@ -136,22 +157,6 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
         [self setCenterViewController:centerViewController];
         [self setLeftDrawerViewController:leftDrawerViewController];
         [self setRightDrawerViewController:rightDrawerViewController];
-    
-        [self setMaximumLeftDrawerWidth:MMDrawerDefaultWidth];
-        [self setMaximumRightDrawerWidth:MMDrawerDefaultWidth];
-        
-        [self setAnimationVelocity:MMDrawerDefaultAnimationVelocity];
-        
-        [self setShowsShadow:YES];
-        [self setShouldStretchDrawer:YES];
-        
-        [self setOpenDrawerGestureModeMask:MMOpenDrawerGestureModeNone];
-        [self setCloseDrawerGestureModeMask:MMCloseDrawerGestureModeNone];
-        [self setCenterHiddenInteractionMode:MMDrawerOpenCenterInteractionModeNavigationBarOnly];
-        
-        [self.view setBackgroundColor:[UIColor blackColor]];
-        
-        [self setupGestureRecognizers];
     }
     return self;
 }
@@ -543,6 +548,16 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 
 -(BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers{
     return NO;
+}
+
+#pragma mark - View Lifecycle
+
+- (void)viewDidLoad {
+	[super viewDidLoad];
+
+	[self.view setBackgroundColor:[UIColor blackColor]];
+
+	[self setupGestureRecognizers];
 }
 
 -(void)viewWillAppear:(BOOL)animated{


### PR DESCRIPTION
Replace initializing code into initWithNibName:bundle:. 
Before that if we're using [MMDrawerController new]; - no setup occured and different options stay uninitialized.

Also i move [self.view setBackgroundColor:]; & gesture recognizers setup to viewDidLoad:
Calling self.view in init leads to view load & inefficient resources usage.
