### PR TITLE
Weird edge case issue with DrawerGestureModePanning

### DIFF
--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -58,9 +58,11 @@ typedef NS_OPTIONS(NSInteger, MMOpenDrawerGestureMode) {
     MMOpenDrawerGestureModePanningNavigationBar     = 1 << 1,
     MMOpenDrawerGestureModePanningCenterView        = 1 << 2,
     MMOpenDrawerGestureModeBezelPanningCenterView   = 1 << 3,
-    MMOpenDrawerGestureModeAll                      =   MMOpenDrawerGestureModePanningNavigationBar |
-                                                        MMOpenDrawerGestureModePanningCenterView    |
-                                                        MMOpenDrawerGestureModeBezelPanningCenterView,
+    MMOpenDrawerGestureModeCustom                   = 1 << 4,
+    MMOpenDrawerGestureModeAll                      =   MMOpenDrawerGestureModePanningNavigationBar     |
+                                                        MMOpenDrawerGestureModePanningCenterView        |
+                                                        MMOpenDrawerGestureModeBezelPanningCenterView   |
+                                                        MMOpenDrawerGestureModeCustom,
 };
 
 typedef NS_OPTIONS(NSInteger, MMCloseDrawerGestureMode) {
@@ -71,12 +73,14 @@ typedef NS_OPTIONS(NSInteger, MMCloseDrawerGestureMode) {
     MMCloseDrawerGestureModeTapNavigationBar        = 1 << 4,
     MMCloseDrawerGestureModeTapCenterView           = 1 << 5,
     MMCloseDrawerGestureModePanningDrawerView       = 1 << 6,
+    MMCloseDrawerGestureModeCustom                  = 1 << 7,
     MMCloseDrawerGestureModeAll                     =   MMCloseDrawerGestureModePanningNavigationBar    |
                                                         MMCloseDrawerGestureModePanningCenterView       |
                                                         MMCloseDrawerGestureModeBezelPanningCenterView  |
                                                         MMCloseDrawerGestureModeTapNavigationBar        |
                                                         MMCloseDrawerGestureModeTapCenterView           |
-                                                        MMCloseDrawerGestureModePanningDrawerView,
+                                                        MMCloseDrawerGestureModePanningDrawerView       |
+                                                        MMCloseDrawerGestureModeCustom,
 };
 
 typedef NS_ENUM(NSInteger, MMDrawerOpenCenterInteractionMode) {
@@ -362,5 +366,20 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  @param drawerVisualStateBlock A block object to be called that allows the implementer to update visual state properties on the drawer. `percentVisible` represents the amount of the drawer space that is current visible, with drawer space being defined as the edge of the screen to the maxmimum drawer width. Note that you do have access to the drawerController, which will allow you to update things like the anchor point of the side drawer layer.
  */
 -(void)setDrawerVisualStateBlock:(void(^)(MMDrawerController * drawerController, MMDrawerSide drawerSide, CGFloat percentVisible))drawerVisualStateBlock;
+
+///---------------------------------------
+/// @name Custom Gesture Handler
+///---------------------------------------
+
+/**
+ Sets a callback to be called to determine if a UIGestureRecognizer should recieve the given UITouch.
+ 
+ This block provides a way to allow a gesture to be recognized with custom logic. For example, you may have a certain part of your view that should accept a pan gesture recognizer to open the drawer, but not another a part. If you return YES, the gesture is recognized and the appropriate action is taken. This provides similar to support to how Facebook allows your to pan on the background view of the main table view, but not the content itself.
+ 
+ Note that either `openDrawerGestureModeMask` must contain `MMOpenDrawerGestureModeCustom`, or `closeDrawerGestureModeMask` must contain `MMCloseDrawerGestureModeCustom` for this block to be consulted.
+ 
+ @param gestureShouldRecognizeTouchBlock A block object to be called to determine if the given `touch` should be recognized by the given gesture.
+ */
+-(void)setGestureShouldRecognizeTouchBlock:(BOOL(^)(MMDrawerController * drawerController, UIGestureRecognizer * gesture, UITouch * touch))gestureShouldRecognizeTouchBlock;
 
 @end

--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -385,7 +385,7 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
 /**
  Sets a callback to be called to determine if a UIGestureRecognizer should recieve the given UITouch.
  
- This block provides a way to allow a gesture to be recognized with custom logic. For example, you may have a certain part of your view that should accept a pan gesture recognizer to open the drawer, but not another a part. If you return YES, the gesture is recognized and the appropriate action is taken. This provides similar to support to how Facebook allows your to pan on the background view of the main table view, but not the content itself.
+ This block provides a way to allow a gesture to be recognized with custom logic. For example, you may have a certain part of your view that should accept a pan gesture recognizer to open the drawer, but not another a part. If you return YES, the gesture is recognized and the appropriate action is taken. This provides similar support to how Facebook allows you to pan on the background view of the main table view, but not the content itself. You can inspect the `openSide` property of the `drawerController` to determine the current state of the drawer, and apply the appropriate logic within your block.
  
  Note that either `openDrawerGestureModeMask` must contain `MMOpenDrawerGestureModeCustom`, or `closeDrawerGestureModeMask` must contain `MMCloseDrawerGestureModeCustom` for this block to be consulted.
  

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ MMDrawerController * drawerController = [[MMDrawerController alloc]
  * **MMOpenDrawerGestureModePanningNavigationBar**: The user can open the drawer by panning anywhere on the navigation bar.
  * **MMOpenDrawerGestureModePanningCenterView**: The user can open the drawer by panning anywhere on the center view.
  * **MMOpenDrawerGestureModeBezelPanningCenterView**: The user can open the drawer by starting a pan anywhere within 20 points of the bezel.
+ * **MMOpenDrawerGestureModeCustom**: The developer can provide a callback block to determine if the gesture should be recognized. More information below.
 
 * **MMCloseDrawerGestureMode**
  * **MMCloseDrawerGestureModePanningNavigationBar**: The user can close the drawer by panning anywhere on the navigation bar.
@@ -62,8 +63,29 @@ MMDrawerController * drawerController = [[MMDrawerController alloc]
  * **MMCloseDrawerGestureModeTapNavigationBar**: The user can close the drawer by tapping the navigation bar.
  * **MMCloseDrawerGestureModeTapCenterView**: The user can close the drawer by tapping the center view.
  * **MMCloseDrawerGestureModePanningDrawerView**: The user can close the drawer by panning anywhere on the drawer view.
+ * **MMCloseDrawerGestureModeCustom**: The developer can provide a callback block to determine if the gesture should be recognized. More information below.
  
 You are free to set whatever combination you want for opening and closing. Note that these gestures may impact touches sent to the child view controllers, so be sure to use these appropriately for your application. For example, you wouldn't want `MMOpenDrawerGestureModePanningCenterView` set if a `MKMapView` is your center view controller, since it would intercept the pan meant for moving around the map.
+
+####Custom Gesture Recognizer Support
+Starting with version 0.3.0, you can now provide a callback block to determine if a gesture should be recognized using the `setGestureShouldRecognizeTouchBlock:` method. This method provides three parameters - the drawer controller, the gesture, and the touch. As a developer, you are responsible for inspecting those elements and determining if the gesture should be recognized or not. Note the block is only consulting if you have set `MMOpenDrawerGestureModeCustom`/`MMCloseDrawerGestureModeCustom` on the appropriate mask.
+
+For example, lets say you have a center view controller that contains a few elements, and you only want the pan gesture to be recognized to open the drawer when the touch begins within a certain subview. You would make sure that the `openDrawerGestureModeMask` contains `MMOpenDrawerGestureModeCustom`, and you could set a block below as so:
+
+```Objective-C
+[myDrawerController
+ setGestureShouldRecognizeTouchBlock:^BOOL(MMDrawerController *drawerController, UIGestureRecognizer *gesture, UITouch *touch) {
+     BOOL shouldRecognizeTouch = NO;
+     if(drawerController.openSide == MMDrawerSideNone &&
+        [gesture isKindOfClass:[UIPanGestureRecognizer class]]){
+         UIView * customView = [drawerController.centerViewController myCustomSubview];
+         CGPoint location = [touch locationInView:customView];
+         shouldRecognizeTouch = (CGRectContainsPoint(customView.bounds, location));
+     }
+     return shouldRecognizeTouch;
+ }];
+ ```
+ Note that you would not want the `openDrawerGestureModeMask` to contain `MMOpenDrawerGestureModePanningCenterView`, since that would take over and be applied automatically regardless of where the touch begins within the center view.
 
 ###Custom Drawer Open/Close Animations
 `MMDrawerController` provides a callback block that allows you to implement your own custom state for the drawer controller when an open/close or pan gesture event happens. Within the block, you are responsible for updating the visual state of the drawer controller, and the drawer controller will handle animating to that state.


### PR DESCRIPTION
Our case is we have a central view, that uses a custom navigation bar, and not a standard navigation controller. So by appearances, there looks to be a navigation bar on screen.

Our central view has a drawing/annotating element, so needs to listen to touch events, which the center panning mode is eating up.

If I set the open/close drawer mask to MMOpenDrawerGestureModePanningNavigationBar, the center basically goes dead. 

There is a redesign of the center controller's UI underway, but any alternatives in the meantime?
