### PR TITLE
Fixed Overshoot Transform Bug

### DIFF
--- a/KitchenSink/ExampleFiles/MMExampleDrawerVisualStateManager.m
+++ b/KitchenSink/ExampleFiles/MMExampleDrawerVisualStateManager.m
@@ -63,32 +63,21 @@
         default:
             visualStateBlock =  ^(MMDrawerController * drawerController, MMDrawerSide drawerSide, CGFloat percentVisible){
                 
-                UIViewController * sideDrawerViewController;
-                CATransform3D transform;
-                CGFloat maxDrawerWidth;
-                
-                if(drawerSide == MMDrawerSideLeft){
-                    sideDrawerViewController = drawerController.leftDrawerViewController;
-                    maxDrawerWidth = drawerController.maximumLeftDrawerWidth;
+                if (percentVisible > 1.f) {
+                    MMDrawerControllerDrawerVisualStateBlock stateBlock = [MMDrawerVisualState parallaxVisualStateBlockWithParallaxFactor:1.f];
+                    stateBlock(drawerController, drawerSide, percentVisible);
                 }
-                else if(drawerSide == MMDrawerSideRight){
-                    sideDrawerViewController = drawerController.rightDrawerViewController;
-                    maxDrawerWidth = drawerController.maximumRightDrawerWidth;
-                }
-                
-                if(percentVisible > 1.0){
-                    transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-                    
-                    if(drawerSide == MMDrawerSideLeft){
-                        transform = CATransform3DTranslate(transform, maxDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
-                    }else if(drawerSide == MMDrawerSideRight){
-                        transform = CATransform3DTranslate(transform, -maxDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+                else{
+                    UIViewController *viewController = nil;
+                    if (drawerSide == MMDrawerSideLeft) {
+                        viewController = drawerController.leftDrawerViewController;
                     }
+                    else if(drawerSide == MMDrawerSideRight){
+                        viewController = drawerController.rightDrawerViewController;
+                    }
+                    
+                    viewController.view.layer.transform = CATransform3DIdentity;
                 }
-                else {
-                    transform = CATransform3DIdentity;
-                }
-                [sideDrawerViewController.view.layer setTransform:transform];
             };
             break;
     }

--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -85,6 +85,12 @@ typedef NS_ENUM(NSInteger, MMDrawerOpenCenterInteractionMode) {
     MMDrawerOpenCenterInteractionModeNavigationBarOnly,
 };
 
+/**
+ The percent of the possible overshoot width to use as the actual overshoot percentage.
+   Exposed here to compensate for overshoot calculations in the visual state blocks.
+ */
+extern CGFloat const MMDrawerOvershootPercentage;
+
 @class  MMDrawerController;
 typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * drawerController, MMDrawerSide drawerSide, CGFloat percentVisible);
 

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -771,6 +771,10 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
         case UIGestureRecognizerStateBegan:
             self.startingPanRect = self.centerContainerView.frame;
         case UIGestureRecognizerStateChanged:{
+            [CATransaction begin];
+            /** Disable implicit animations for layer changes since this is a continuous pan */
+            [CATransaction setDisableActions:YES];
+            
             CGRect newFrame = self.startingPanRect;
             CGPoint translatedPoint = [panGesture translationInView:self.centerContainerView];
             newFrame.origin.x = [self roundedOriginXForDrawerConstriants:CGRectGetMinX(self.startingPanRect)+translatedPoint.x];
@@ -807,6 +811,8 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
             [self updateDrawerVisualStateForDrawerSide:visibleSide percentVisible:percentVisible];
             
             [self.centerContainerView setCenter:CGPointMake(CGRectGetMidX(newFrame), CGRectGetMidY(newFrame))];
+            
+            [CATransaction commit];
             break;
         }
         case UIGestureRecognizerStateCancelled:
@@ -865,6 +871,7 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 }
 
 -(void)updateDrawerVisualStateForDrawerSide:(MMDrawerSide)drawerSide percentVisible:(CGFloat)percentVisible{
+    /** This logic is broken in the demo project since drawerVisualState is never nil */
     if(self.drawerVisualState){
         self.drawerVisualState(self,drawerSide,percentVisible);
     }
@@ -876,17 +883,29 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 - (void)applyOvershootScaleTransformForDrawerSide:(MMDrawerSide)drawerSide percentVisible:(CGFloat)percentVisible{
     
     if (percentVisible >= 1.f) {
-        CATransform3D transform;
         UIViewController * sideDrawerViewController = [self sideDrawerViewControllerForSide:drawerSide];
+        CGFloat maxDrawerWidth = 0.f;
+        CGFloat unscaledMaxWidth = 0.f;
+        
         if(drawerSide == MMDrawerSideLeft) {
-            transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-            transform = CATransform3DTranslate(transform, self.maximumLeftDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+            maxDrawerWidth = MAX(self.maximumLeftDrawerWidth, self.visibleLeftDrawerWidth);
+            unscaledMaxWidth = self.maximumLeftDrawerWidth;
         }
         else if(drawerSide == MMDrawerSideRight){
-            transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-            transform = CATransform3DTranslate(transform, -self.maximumRightDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+            maxDrawerWidth = MAX(self.maximumRightDrawerWidth, self.visibleRightDrawerWidth);
+            unscaledMaxWidth = self.maximumRightDrawerWidth;
         }
-        sideDrawerViewController.view.layer.transform = transform;
+        
+        CATransform3D overshootTransform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
+        
+        NSInteger scalingModifier = 1.f;
+        if (drawerSide == MMDrawerSideRight) {
+            scalingModifier = -1.f;
+        }
+        CGFloat translationCorrection = scalingModifier*(maxDrawerWidth*MMDrawerOvershootPercentage)*(percentVisible-1);
+        overshootTransform = CATransform3DTranslate(overshootTransform, scalingModifier*unscaledMaxWidth*(percentVisible-1.f)/2-translationCorrection, 0.f, 0.f);
+        
+        sideDrawerViewController.view.layer.transform = overshootTransform;
     }
 }
 


### PR DESCRIPTION
I finally fixed the one thing that's been bother me about MMDrawer since it was launched: the overshoot transform issue that was evident when you over-panned a view.

You could see that the overshoot was under/over translating the view after it was scaled depending on which drawer side was being panned. This had to do with not taking the overshoot into account when translating the view to correct for the new scaled size.

This issue was more evident on the iPad form factor than the iPhone due to having more horizontal points.
