### PR TITLE
Gesture completion block not executed when panning to the left (until the end of screen)

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -862,6 +862,11 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
             [self openDrawerSide:MMDrawerSideRight animated:YES completion:completion];
         }
     }
+    else {
+        if(completion){
+            completion(NO);
+        }
+    }
 }
 
 -(void)updateDrawerVisualStateForDrawerSide:(MMDrawerSide)drawerSide percentVisible:(CGFloat)percentVisible{


### PR DESCRIPTION
The gesture completion block is not being called when the center UIViewController is panned all the way to the left side. If you release your finger from the screen, while panning to the left, before the center view reaches the left side, then the gesture completion block will be executed.

Exposing the left view by panning the center view all the way to the right side of the screen will, correctly, as result the  gesture completion block to be executed.
