### PR TITLE
Fix crash bug due to Infinite Loop

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -150,7 +150,7 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 
 -(id)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
     NSParameterAssert(centerViewController);
-    self = [self init];
+    self = [super init];
     if(self){
         [self setCenterViewController:centerViewController];
         [self setLeftDrawerViewController:leftDrawerViewController];


### PR DESCRIPTION
Hi,

I encounter a crash bug when doing as follow:
1) Subclassing MMDrawerController 
2) Override -init method (My intention was to create a controller class act like Tabbar controller, therefore I want to hide away MMDrawerController init methods)
3) In -init method call self = [super initWithCenterViewController:_centerViewController leftDrawerViewController:_leftDrawerViewController];

The app crash due to infinite loop at above line of code (in step 3).

The fix is simply change [self init]  to [super init] in -[MMDrawerController initWithCenterViewController: leftDrawerViewController: rightDrawerViewController:]

Best regards,
Tuan.
