### PR TITLE
Setting a valid transform value for a two visual state blocks

### DIFF
--- a/MMDrawerController/MMDrawerVisualState.m
+++ b/MMDrawerController/MMDrawerVisualState.m
@@ -32,7 +32,7 @@
         
         CGFloat maxDistance = 50;
         CGFloat distance = maxDistance * percentVisible;
-        CATransform3D translateTransform;
+        CATransform3D translateTransform = CATransform3DIdentity;
         UIViewController * sideDrawerViewController;
         if(drawerSide == MMDrawerSideLeft) {
             sideDrawerViewController = drawerController.leftDrawerViewController;
@@ -117,7 +117,7 @@
     MMDrawerControllerDrawerVisualStateBlock visualStateBlock =
     ^(MMDrawerController * drawerController, MMDrawerSide drawerSide, CGFloat percentVisible){
         NSParameterAssert(parallaxFactor >= 1.0);
-        CATransform3D transform;
+        CATransform3D transform = CATransform3DIdentity;
         UIViewController * sideDrawerViewController;
         if(drawerSide == MMDrawerSideLeft) {
             sideDrawerViewController = drawerController.leftDrawerViewController;


### PR DESCRIPTION
Looks like there is a case where these values could be undefined if the side is None, so setting these to the identity for that case.

May solve #61 and #30 

@larsacus for the review...
