### PR TITLE
Unbalanced calls to begin/end appearance transitions using non-animated setCenterViewController:withCloseAnimation:completion: 

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -362,7 +362,8 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
 }
 
 -(void)setCenterViewController:(UIViewController *)newCenterViewController withFullCloseAnimation:(BOOL)animated completion:(void(^)(BOOL))completion{
-    if(self.openSide != MMDrawerSideNone){
+    if(self.openSide != MMDrawerSideNone &&
+       animated){
         
         UIViewController * sideDrawerViewController = [self sideDrawerViewControllerForSide:self.openSide];
         
@@ -425,6 +426,9 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
     }
     else {
         [self setCenterViewController:newCenterViewController animated:animated];
+        if(self.openSide != MMDrawerSideNone){
+            [self closeDrawerAnimated:animated completion:completion];
+        }
     }
 }
 


### PR DESCRIPTION
If you call this method to set the centre view controller with withCloseAnimation set to NO you will see log messages about "Unbalanced calls to begin/end appearance transitions ... ".  It appears in this case MMDrawerController calls the transition methods twice on the current center, i.e.:

beginAppearanceTransition:animated:
beginAppearanceTransition:animated:
endAppearanceTransition
endAppearanceTransition

They are called both in this method directly and also in a nested call to setCenterViewController:animated: because animated is NO.  I've worked around this by changing the center controller by setting the property directly (which just calls the private setCenterViewController:animated:).
