### PR TITLE
Fix: StatusBar cannot be hidden in iOS7

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -555,6 +555,14 @@ static CAKeyframeAnimation * bounceKeyFrameAnimationForDistanceOnView(CGFloat di
     return NO;
 }
 
+- (UIViewController *)childViewControllerForStatusBarHidden {
+    return self.centerViewController;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle {
+    return self.centerViewController;
+}
+
 #pragma mark - View Lifecycle
 
 - (void)viewDidLoad {


### PR DESCRIPTION
The hidden status of StatusBar should be controlled by child view
controller in iOS 7.
