### PR TITLE
wrap 'setNeedsStatusBarAppearanceUpdate' within performSelector:

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -979,7 +979,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 
 -(void)setNeedsStatusBarAppearanceUpdateIfSupported{
     if([self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]){
-        [self setNeedsStatusBarAppearanceUpdate];
+        [self performSelector:@selector(setNeedsStatusBarAppearanceUpdate)];
     }
 }
 


### PR DESCRIPTION
Could you guys replace tag 0.5.0 with this commit instead?
0.5.0 is broken on iOS 6 (as it doesn't compile). Shouldn't push tags with broken builds. 
No biggie though. 
