### PR TITLE
Support Highlighting for iOS 7 Drawer Button Item

### DIFF
--- a/MMDrawerController/MMDrawerBarButtonItem.m
+++ b/MMDrawerController/MMDrawerBarButtonItem.m
@@ -248,7 +248,7 @@
     }
     else {
         MMDrawerMenuButtonView * buttonView = [[MMDrawerMenuButtonView alloc] initWithFrame:CGRectMake(0, 0, 26, 26)];
-        [buttonView addTarget:target action:action forControlEvents:UIControlEventTouchUpInside];
+        [buttonView addTarget:self action:@selector(touchUpInside:) forControlEvents:UIControlEventTouchUpInside];
         self = [self initWithCustomView:buttonView];
         if(self){
             [self setButtonView:buttonView];


### PR DESCRIPTION
This set of changes enables touch/highlight state in iOS7 for the MMDrawerBarButtonItem.  It also adds an initWithCoder: method for xib/storyboard support, and tweaks the iOS6 codepath such that the bar button item action sender is now the bar button item itself, not the UIButton custom-view.
