### PR TITLE
Fix for issue #123

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -111,6 +111,9 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
         }
         else {
             navBar = [self navigationBarContainedWithinSubviewsOfView:subview];
+            if (navBar != nil) {
+                break;
+            }
         }
     }
     return navBar;


### PR DESCRIPTION
MMDrawerOpenCenterInteractionModeNavigationBarOnly fails if navigation controller's toolbar is shown.

Regarding the repro steps in the issue, note that showing the toolbar in the example project isn't sufficient to produce the bug; the touch event is handled elsewhere so it looks like the button is working properly.
