### PR TITLE
Fade in/out status bar background like a facebook.

### DIFF
--- a/KitchenSink/ExampleFiles/MMAppDelegate.m
+++ b/KitchenSink/ExampleFiles/MMAppDelegate.m
@@ -56,6 +56,7 @@
                             leftDrawerViewController:leftSideNavController
                             rightDrawerViewController:rightSideNavController];
         [self.drawerController setShowsShadow:NO];
+        [self.drawerController setFadeStatusBarBackgroundView:YES];
     }
     else{
          self.drawerController = [[MMDrawerController alloc]

--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -214,6 +214,13 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  */
 @property (nonatomic, strong) UIColor * statusBarViewBackgroundColor;
 
+/**
+ The flag determining if status bar background view should fade out(alpha 0) when a side drawer is close. If this flag is set to YES, it will change 'showsStatusBarBackgroundView' to YES. This property is only available when 'showsStatusBarBackgroundView' can be set to YES or igonred.
+ 
+ By default, this is set to NO..
+ */
+@property (nonatomic, assign) BOOL fadeStatusBarBackgroundView;
+
 ///---------------------------------------
 /// @name Initializing a `MMDrawerController`
 ///---------------------------------------

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -819,8 +819,14 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
             _showsStatusBarBackgroundView = showsDummyStatusBar;
             CGRect frame = self.childControllerContainerView.frame;
             if(_showsStatusBarBackgroundView){
-                frame.origin.y = 20;
-                frame.size.height = CGRectGetHeight(self.view.bounds)-20;
+                if (_fadeStatusBarBackgroundView) {
+                    frame.origin.y = 0;
+                    frame.size.height = CGRectGetHeight(self.view.bounds);
+                    [self.dummyStatusBarView setAlpha:0];
+                } else {
+                    frame.origin.y = 20;
+                    frame.size.height = CGRectGetHeight(self.view.bounds)-20;
+                }
             }
             else {
                 frame.origin.y = 0;
@@ -838,6 +844,30 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 -(void)setStatusBarViewBackgroundColor:(UIColor *)dummyStatusBarColor{
     _statusBarViewBackgroundColor = dummyStatusBarColor;
     [self.dummyStatusBarView setBackgroundColor:_statusBarViewBackgroundColor];
+}
+
+-(void)setFadeStatusBarBackgroundView:(BOOL)fadeStatusBarBackgroundView{
+    if(fadeStatusBarBackgroundView!=_fadeStatusBarBackgroundView){
+        _fadeStatusBarBackgroundView = fadeStatusBarBackgroundView;
+        CGRect frame = self.childControllerContainerView.frame;
+        if (_fadeStatusBarBackgroundView) {
+            if (_showsStatusBarBackgroundView) {
+                frame.origin.y = 0;
+                frame.size.height = CGRectGetHeight(self.view.bounds);
+                [self.dummyStatusBarView setAlpha:0];
+                [self.childControllerContainerView setFrame:frame];
+            } else {
+                [self setShowsStatusBarBackgroundView:YES];
+            }
+        } else {
+            if (_showsStatusBarBackgroundView) {
+                frame.origin.y = 20;
+                frame.size.height = CGRectGetHeight(self.view.bounds)-20;
+                [self.dummyStatusBarView setAlpha:1];
+                [self.childControllerContainerView setFrame:frame];
+            }
+        }
+    }
 }
 
 #pragma mark - Getters
@@ -1036,6 +1066,9 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     }
     else if(self.shouldStretchDrawer){
         [self applyOvershootScaleTransformForDrawerSide:drawerSide percentVisible:percentVisible];
+    }
+    if(_showsStatusBarBackgroundView && _fadeStatusBarBackgroundView) {
+        [self.dummyStatusBarView setAlpha:percentVisible];
     }
 }
 


### PR DESCRIPTION
Status bar fade in/out when side drawer is open/close for iOS 7.

| Closed | Transiting | Opend |
| --- | --- | --- |
| ![alt tag](https://docs.google.com/uc?export=download&id=0B7CRbK0yMwIIRFdkR3BfVlhadmM) | ![alt tag](https://docs.google.com/uc?export=download&id=0B7CRbK0yMwIIY3VLbFExYmxRczA) | ![alt tag](https://docs.google.com/uc?export=download&id=0B7CRbK0yMwIIa2U5bEdrT0hlS3c) |
