### PR TITLE
Tweaked translation amount so stretch doesn't leave empty space

### DIFF
--- a/KitchenSink/ExampleFiles/MMExampleDrawerVisualStateManager.m
+++ b/KitchenSink/ExampleFiles/MMExampleDrawerVisualStateManager.m
@@ -80,9 +80,9 @@
                     transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
                     
                     if(drawerSide == MMDrawerSideLeft){
-                        transform = CATransform3DTranslate(transform, maxDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+                        transform = CATransform3DTranslate(transform, maxDrawerWidth*(percentVisible-1.f)/(2*percentVisible), 0.f, 0.f);
                     }else if(drawerSide == MMDrawerSideRight){
-                        transform = CATransform3DTranslate(transform, -maxDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+                        transform = CATransform3DTranslate(transform, -maxDrawerWidth*(percentVisible-1.f)/(2*percentVisible), 0.f, 0.f);
                     }
                 }
                 else {

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -1040,17 +1040,16 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 }
 
 - (void)applyOvershootScaleTransformForDrawerSide:(MMDrawerSide)drawerSide percentVisible:(CGFloat)percentVisible{
-    
     if (percentVisible >= 1.f) {
         CATransform3D transform = CATransform3DIdentity;
         UIViewController * sideDrawerViewController = [self sideDrawerViewControllerForSide:drawerSide];
         if(drawerSide == MMDrawerSideLeft) {
             transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-            transform = CATransform3DTranslate(transform, self.maximumLeftDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+            transform = CATransform3DTranslate(transform, self.maximumLeftDrawerWidth*(percentVisible-1.f)/(2*percentVisible), 0.f, 0.f);
         }
         else if(drawerSide == MMDrawerSideRight){
             transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-            transform = CATransform3DTranslate(transform, -self.maximumRightDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+            transform = CATransform3DTranslate(transform, -self.maximumRightDrawerWidth*(percentVisible-1.f)/(2*percentVisible), 0.f, 0.f);
         }
         sideDrawerViewController.view.layer.transform = transform;
     }

--- a/MMDrawerController/MMDrawerVisualState.m
+++ b/MMDrawerController/MMDrawerVisualState.m
@@ -68,14 +68,14 @@
             sideDrawerViewController = drawerController.leftDrawerViewController;
             anchorPoint =  CGPointMake(1.0, .5);
             maxDrawerWidth = MAX(drawerController.maximumLeftDrawerWidth,drawerController.visibleLeftDrawerWidth);
-            xOffset = -(maxDrawerWidth/2.0) + (maxDrawerWidth)*percentVisible;
+            xOffset = -(maxDrawerWidth/2.0)/percentVisible + (maxDrawerWidth)*percentVisible;
             angle = -M_PI_2+(percentVisible*M_PI_2);
         }
         else {
             sideDrawerViewController = drawerController.rightDrawerViewController;
             anchorPoint = CGPointMake(0.0, .5);
             maxDrawerWidth = MAX(drawerController.maximumRightDrawerWidth,drawerController.visibleRightDrawerWidth);
-            xOffset = (maxDrawerWidth/2.0) - (maxDrawerWidth)*percentVisible;
+            xOffset = (maxDrawerWidth/2.0)/percentVisible - (maxDrawerWidth)*percentVisible;
             angle = M_PI_2-(percentVisible*M_PI_2);
         }
         
@@ -104,7 +104,7 @@
                 scalingModifier = -1.f;
             }
             
-            overshootTransform = CATransform3DTranslate(overshootTransform, scalingModifier*maxDrawerWidth/2, 0.f, 0.f);
+            overshootTransform = CATransform3DTranslate(overshootTransform, scalingModifier*maxDrawerWidth/(2*percentVisible), 0.f, 0.f);
             swingingDoorTransform = overshootTransform;
         }
         
@@ -127,7 +127,7 @@
             }
             else{
                 transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-                transform = CATransform3DTranslate(transform, drawerController.maximumLeftDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+                transform = CATransform3DTranslate(transform, drawerController.maximumLeftDrawerWidth*(percentVisible-1.f)/(2*percentVisible), 0.f, 0.f);
             }
         }
         else if(drawerSide == MMDrawerSideRight){
@@ -138,7 +138,7 @@
             }
             else{
                 transform = CATransform3DMakeScale(percentVisible, 1.f, 1.f);
-                transform = CATransform3DTranslate(transform, -drawerController.maximumRightDrawerWidth*(percentVisible-1.f)/2, 0.f, 0.f);
+                transform = CATransform3DTranslate(transform, -drawerController.maximumRightDrawerWidth*(percentVisible-1.f)/(2*percentVisible), 0.f, 0.f);
             }
         }
         

--- a/MMDrawerController/MMDrawerVisualState.m
+++ b/MMDrawerController/MMDrawerVisualState.m
@@ -60,6 +60,7 @@
         UIViewController * sideDrawerViewController;
         CGPoint anchorPoint;
         CGFloat maxDrawerWidth = 0.0;
+        CGFloat actualMaxDrawerWidth = 0.0;
         CGFloat xOffset;
         CGFloat angle = 0.0;
         
@@ -67,15 +68,17 @@
             
             sideDrawerViewController = drawerController.leftDrawerViewController;
             anchorPoint =  CGPointMake(1.0, .5);
+            actualMaxDrawerWidth = drawerController.maximumLeftDrawerWidth;
             maxDrawerWidth = MAX(drawerController.maximumLeftDrawerWidth,drawerController.visibleLeftDrawerWidth);
-            xOffset = -(maxDrawerWidth/2.0)/percentVisible + (maxDrawerWidth)*percentVisible;
+            xOffset = -(maxDrawerWidth/2.0) + (maxDrawerWidth)*percentVisible;
             angle = -M_PI_2+(percentVisible*M_PI_2);
         }
         else {
             sideDrawerViewController = drawerController.rightDrawerViewController;
             anchorPoint = CGPointMake(0.0, .5);
+            actualMaxDrawerWidth = drawerController.maximumRightDrawerWidth;
             maxDrawerWidth = MAX(drawerController.maximumRightDrawerWidth,drawerController.visibleRightDrawerWidth);
-            xOffset = (maxDrawerWidth/2.0)/percentVisible - (maxDrawerWidth)*percentVisible;
+            xOffset = (maxDrawerWidth/2.0) - (maxDrawerWidth)*percentVisible;
             angle = M_PI_2-(percentVisible*M_PI_2);
         }
         
@@ -104,7 +107,8 @@
                 scalingModifier = -1.f;
             }
             
-            overshootTransform = CATransform3DTranslate(overshootTransform, scalingModifier*maxDrawerWidth/(2*percentVisible), 0.f, 0.f);
+            CATransform3D translateTransform = CATransform3DMakeTranslation(scalingModifier*(maxDrawerWidth*2-actualMaxDrawerWidth)/2.f, 0.f, 0.f);
+            overshootTransform = CATransform3DConcat(overshootTransform, translateTransform);
             swingingDoorTransform = overshootTransform;
         }
         


### PR DESCRIPTION
I noticed a problem with the way the stretch translation was working. It was overshooting too far and leaving some blank space. This fix solved that issue for me, so now the stretch transformation keeps the side view controller anchored to the edge of the screen and to the edge of the center view controller.

Now, it's dividing the visiblePercentage out of the translation, along with the '2' that you were using. There might be a better way to do this altogether, but I'm not exactly sure. The transformation order seems correct (scale => translate), but I can't spend much more time on this, maybe you or someone else will see this and immediately know the answer.

*** NOTE ***
I didn't fully test all areas I changed here, so you might want to test my changed files individually. I made the same changes to a few other similar pieces of code, but it looks like the transformations are a little different in those spots. ANYWAY, the two areas I did test:  A) Parallax mode in the KitchenSink demo.  B) MMDrawerController's "applyOvershootScaleTransformForDrawerSide" (which I tested in my own code).