### PR TITLE
Fix state-restoration ordering of child controllers

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -196,16 +196,16 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 #pragma mark - State Restoration
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder{
     [super encodeRestorableStateWithCoder:coder];
+    if (self.centerViewController){
+        [coder encodeObject:self.centerViewController forKey:MMDrawerCenterKey];
+    }
+
     if (self.leftDrawerViewController){
         [coder encodeObject:self.leftDrawerViewController forKey:MMDrawerLeftDrawerKey];
     }
 
     if (self.rightDrawerViewController){
         [coder encodeObject:self.rightDrawerViewController forKey:MMDrawerRightDrawerKey];
-    }
-
-    if (self.centerViewController){
-        [coder encodeObject:self.centerViewController forKey:MMDrawerCenterKey];
     }
 
     [coder encodeInteger:self.openSide forKey:MMDrawerOpenSideKey];
@@ -216,6 +216,10 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     MMDrawerSide openside;
 
     [super decodeRestorableStateWithCoder:coder];
+
+    if ((controller = [coder decodeObjectForKey:MMDrawerCenterKey])){
+        self.centerViewController = controller;
+    }
     
     if ((controller = [coder decodeObjectForKey:MMDrawerLeftDrawerKey])){
         self.leftDrawerViewController = [coder decodeObjectForKey:MMDrawerLeftDrawerKey];
@@ -223,10 +227,6 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 
     if ((controller = [coder decodeObjectForKey:MMDrawerRightDrawerKey])){
         self.rightDrawerViewController = controller;
-    }
-
-    if ((controller = [coder decodeObjectForKey:MMDrawerCenterKey])){
-        self.centerViewController = controller;
     }
 
     if ((openside = [coder decodeIntegerForKey:MMDrawerOpenSideKey])){


### PR DESCRIPTION
Hi there - I was having problems with state restoration only working the first time around.  I believe it's due to the ordering of the drawer's child controllers - in the init method, you end up with [center, left, right] child controllers, but when decoding from state restoration, you have [left, right, center].  This then means that the state restoration paths don't match up, so it fails.

This commit re-orders the state-restoration decode method to be consistent with the regular init method.
