### PR TITLE
Two childControllerContainerView's are initialized

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -874,10 +874,20 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 
 -(UIView*)childControllerContainerView{
     if(_childControllerContainerView == nil){
-        _childControllerContainerView = [[UIView alloc] initWithFrame:self.view.bounds];
-        [_childControllerContainerView setBackgroundColor:[UIColor clearColor]];
-        [_childControllerContainerView setAutoresizingMask:UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth];
-        [self.view addSubview:_childControllerContainerView];
+        //Issue #152 (https://github.com/mutualmobile/MMDrawerController/issues/152)
+        //Turns out we have two child container views getting added to the view during init,
+        //because the first request self.view.bounds was kicking off a viewDidLoad, which
+        //caused us to be able to fall through this check twice.
+        //
+        //The fix is to grab the bounds, and then check again that the child container view has
+        //not been created.
+        CGRect childContainerViewFrame = self.view.bounds;
+        if(_childControllerContainerView == nil){
+            _childControllerContainerView = [[UIView alloc] initWithFrame:childContainerViewFrame];
+            [_childControllerContainerView setBackgroundColor:[UIColor clearColor]];
+            [_childControllerContainerView setAutoresizingMask:UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth];
+            [self.view addSubview:_childControllerContainerView];
+
     }
     return _childControllerContainerView;
 }


### PR DESCRIPTION
The `-childControllerContainerView` initializes two instances of `_childControllerContainerView`, both are added to the MMDrawerController's view. The issue occurs because the first initialization requests `self.view.bounds`. At that time `self.view` is `nil` so the view gets loaded, and `viewDidLoad` gets called. The `viewDidLoad` method sets the `childControllerContainerView`'s background color which leads to a second initialization of `childControllerContainerView` because at that time the view is still nil:  ![bildschirmfoto 2013-10-28 um 15 39 52](https://f.cloud.github.com/assets/1156152/1420361/e17fca3a-3fde-11e3-9610-4777938ed41f.png)

This can be fixed by modifying the `-childControllerContainerView` method to look like this:

``` objc
-(UIView*)childControllerContainerView{
    if (_childControllerContainerView == nil) {
        CGRect b = self.view.bounds;
        if(_childControllerContainerView == nil) {
            _childControllerContainerView = [[UIView alloc] initWithFrame:b];
            [_childControllerContainerView setBackgroundColor:[UIColor clearColor]];
            [_childControllerContainerView setAutoresizingMask:UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth];
            [self.view addSubview:_childControllerContainerView];
        }
    }
    return _childControllerContainerView;
}
```
