### PR TITLE
Fixed issue 204: center view gets truncated if user holds finger on the screen during the device rotation.

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -743,7 +743,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 
 -(void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation{
     [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-    if (self.animatingDrawer);
+    if (self.animatingDrawer)
     {
         self.startingPanRect = self.centerContainerView.frame;
     }


### PR DESCRIPTION
See https://github.com/mutualmobile/MMDrawerController/issues/204 for reference

Fix description:
If user holds a finger on screen during device rotation and once rotation is complete moves a finger panGestureCallback uses outdated value of self.startingPanRect and adjusts center view improperly. So i'm suggesting to refresh this value just after the rotation.
