### PR TITLE
Disable user interaction during animation

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -902,6 +902,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [self.dummyStatusBarView setBackgroundColor:_statusBarViewBackgroundColor];
 }
 
+-(void)setAnimatingDrawer:(BOOL)animatingDrawer{
+    _animatingDrawer = animatingDrawer;
+    [self.view setUserInteractionEnabled:!animatingDrawer];
+}
+
 #pragma mark - Getters
 -(CGFloat)maximumLeftDrawerWidth{
     if(self.leftDrawerViewController){


### PR DESCRIPTION
I'm using a menu as my drawer's left view controller, and I'd like to disable interaction on that menu while the menu is animating. (The particular problem I'm trying to solve is preventing a user from tapping one option in the menu, then a different option while the drawer is closing.) I've done this by overriding the unpublished method `-setAnimatingDrawer:` in a subclass like so:

``` objective-c
- (void)setAnimatingDrawer:(BOOL)animatingDrawer
{
    // Disable taps on the menu items during animation.
    self.leftDrawerViewController.view.userInteractionEnabled = !animatingDrawer;
    [super setAnimatingDrawer:animatingDrawer];
}
```

but would be interested to know if there were a better way to accomplish this (particularly without grabbing a "private" method).
