### PR TITLE
Updated default drawer width to make hamburger fully visible

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -24,7 +24,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-CGFloat const MMDrawerDefaultWidth = 280.0f;
+CGFloat const MMDrawerDefaultWidth = 260.0f;
 CGFloat const MMDrawerDefaultAnimationVelocity = 840.0f;
 
 NSTimeInterval const MMDrawerDefaultFullAnimationDelay = 0.10f;


### PR DESCRIPTION
I most recently noticed, the default width of the sidebar does not look great when using a hamburger button (e.g. MMDrawerBarButtonItem)
____
See the attached screenshot:
![screenshot 2014-06-10 14 50 43](https://cloud.githubusercontent.com/assets/869950/3230078/90d38394-f09e-11e3-94cc-6499e27e5541.png)


The burger is not fully visible and looks misaligned.

I think it should look like that:
![screenshot 2014-06-10 14 51 48](https://cloud.githubusercontent.com/assets/869950/3230079/96434422-f09e-11e3-8063-4ad1840c980e.png)


A quick search on Google, example of Spotify UI: http://media.idownloadblog.com/wp-content/uploads/2013/10/Spotify-iOS-7-Playlists.jpg

What do you guys think?