### PR TITLE
Fix warning because of duplicate Copy Headers entry

### DIFF
--- a/MMDrawerController.podspec
+++ b/MMDrawerController.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
                        "http://mutualmobile.github.io/MMDrawerController/ExampleImages/example2.png" ]
   
   s.subspec 'Core' do |ss|
-    ss.source_files = 'MMDrawerController/MMDrawerController*', 'MMDrawerController/UIViewController+MMDrawerController*'
+    ss.source_files = 'MMDrawerController/MMDrawerController.{h,m}', 'MMDrawerController/UIViewController+MMDrawerController.{h,m}'
     ss.framework  = 'QuartzCore'
   end
   


### PR DESCRIPTION
The `MMDrawerController+Subclass.h` is duplicated in the Copy Header section of the generate Pods project.