### PR TITLE
Do not forward appearance events to central VC when drawer is offscreen

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -218,7 +218,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [super decodeRestorableStateWithCoder:coder];
     
     if ((controller = [coder decodeObjectForKey:MMDrawerLeftDrawerKey])){
-        self.leftDrawerViewController = [coder decodeObjectForKey:MMDrawerLeftDrawerKey];
+        self.leftDrawerViewController = controller;
     }
 
     if ((controller = [coder decodeObjectForKey:MMDrawerRightDrawerKey])){
@@ -426,8 +426,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [self updateShadowForCenterView];
     
     if(animated == NO){
-        [self.centerViewController beginAppearanceTransition:YES animated:NO];
-        [self.centerViewController endAppearanceTransition];
+        // If drawer is offscreen, then viewWillAppear: will take care of this
+        if(self.view.window) {
+            [self.centerViewController beginAppearanceTransition:YES animated:NO];
+            [self.centerViewController endAppearanceTransition];
+        }
         [self.centerViewController didMoveToParentViewController:self];
     }
 }
@@ -803,6 +806,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     NSParameterAssert(drawerSide != MMDrawerSideNone);
     
     UIViewController *currentSideViewController = [self sideDrawerViewControllerForSide:drawerSide];
+
+    if (currentSideViewController == viewController) {
+        return;
+    }
+
     if (currentSideViewController != nil) {
         [currentSideViewController beginAppearanceTransition:NO animated:NO];
         [currentSideViewController.view removeFromSuperview];


### PR DESCRIPTION
The idea is to avoid sending appearance events when setting new central controller before drawer put into view hierarchy (or offscreen). This PR fixes issue #261 related to state restoration. Related issue #268.

This patch also adds some minor optimization for side controller setter method to avoid reseting the same view controller. This does make sense with state restoration because at the moment all controllers will be set twice, first time when your code actually instantiates other controllers from storyboard and second time while state restoration decoding.

I tested this patch in my app with and without state restoration and everything works. I haven't tested hot-swap of central controller, but I believe it should work as before.

The good thing, it seems state restoration is smart enough and grabs the last instance of sidebar/central controller instantiated using `-[UIStoryboard instantiateViewControllerWithIdentifier:]`. If you create controllers manually, then you end up with two different sets of controllers I assume. 

If you ask me, I do not encode child VCs for my controllers, because I create them in code anyway. Instead, I save properties that will help me to restore the state of those controllers. From my observations, saving child controller is only makes sense when you use embed segue in storyboard, then you leverage Storyboard to save/restore such controller. But essentially it always creates this controller for you, so you never even decode it, you only encode it.
