### PR TITLE
Add property to allow multiple gesture recognizers

### DIFF
--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -214,6 +214,13 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  */
 @property (nonatomic, strong) UIColor * statusBarViewBackgroundColor;
 
+/**
+ To enable other gesture recognizers that might be affected by the UIPanGestureRecognizer instances used for opening and closing a drawer, like the swipe to delete UIPanGestureRecognizer on UITableViewCell instances that have UITableViewCellEditingStyle == UITableViewCellEditingStyleDelete.
+ 
+ By default, this is set to NO. Should be set to YES to enable other gesture recognizers.
+ */
+@property (nonatomic, assign) BOOL shouldAllowMultipleGestureRecognizers;
+
 ///---------------------------------------
 /// @name Initializing a `MMDrawerController`
 ///---------------------------------------

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -187,6 +187,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     
     [self setShowsShadow:YES];
     [self setShouldStretchDrawer:YES];
+    [self setShouldAllowMultipleGestureRecognizers:NO];
     
     [self setOpenDrawerGestureModeMask:MMOpenDrawerGestureModeNone];
     [self setCloseDrawerGestureModeMask:MMCloseDrawerGestureModeNone];
@@ -1302,6 +1303,10 @@ static inline CGFloat originXForDrawerOriginAndTargetOriginOffset(CGFloat origin
                                                                                                        withTouch:touch];
         return ((self.closeDrawerGestureModeMask & possibleCloseGestureModes)>0);
     }
+}
+
+-(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return [self shouldAllowMultipleGestureRecognizers];
 }
 
 #pragma mark Gesture Recogizner Delegate Helpers


### PR DESCRIPTION
To enable other gesture recognisers that might be affected by the UIPanGestureRecognizer instances used for opening and closing a drawer, like the swipe to delete UIPanGestureRecognizer on UITableViewCell instances that have UITableViewCellEditingStyle == UITableViewCellEditingStyleDelete, implement the UIGestureRecognizerDelegate shouldRecognizeSimultaneouslyWithGestureRecognizer method.