### PR TITLE
Interface Builder support

### DIFF
--- a/KitchenSink/ExampleFiles/MMAppDelegate.h
+++ b/KitchenSink/ExampleFiles/MMAppDelegate.h
@@ -21,8 +21,11 @@
 
 #import <UIKit/UIKit.h>
 
+@class MMDrawerController;
+
 @interface MMAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
+@property (strong, nonatomic) IBOutlet UIWindow *window;
+@property (nonatomic,strong) IBOutlet MMDrawerController * drawerController;
 
 @end

--- a/KitchenSink/ExampleFiles/MMAppDelegate.m
+++ b/KitchenSink/ExampleFiles/MMAppDelegate.m
@@ -30,40 +30,15 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-@interface MMAppDelegate ()
-@property (nonatomic,strong) MMDrawerController * drawerController;
-
-@end
-
 @implementation MMAppDelegate
+
 -(BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions{
     
-    UIViewController * leftSideDrawerViewController = [[MMExampleLeftSideDrawerViewController alloc] init];
-
-    UIViewController * centerViewController = [[MMExampleCenterTableViewController alloc] init];
-    
-    UIViewController * rightSideDrawerViewController = [[MMExampleRightSideDrawerViewController alloc] init];
-    
-    UINavigationController * navigationController = [[MMNavigationController alloc] initWithRootViewController:centerViewController];
-    [navigationController setRestorationIdentifier:@"MMExampleCenterNavigationControllerRestorationKey"];
     if(OSVersionIsAtLeastiOS7()){
-        UINavigationController * rightSideNavController = [[MMNavigationController alloc] initWithRootViewController:rightSideDrawerViewController];
-		[rightSideNavController setRestorationIdentifier:@"MMExampleRightNavigationControllerRestorationKey"];
-        UINavigationController * leftSideNavController = [[MMNavigationController alloc] initWithRootViewController:leftSideDrawerViewController];
-		[leftSideNavController setRestorationIdentifier:@"MMExampleLeftNavigationControllerRestorationKey"];
-        self.drawerController = [[MMDrawerController alloc]
-                            initWithCenterViewController:navigationController
-                            leftDrawerViewController:leftSideNavController
-                            rightDrawerViewController:rightSideNavController];
         [self.drawerController setShowsShadow:NO];
     }
     else{
-         self.drawerController = [[MMDrawerController alloc]
-                            initWithCenterViewController:navigationController
-                            leftDrawerViewController:leftSideDrawerViewController
-                            rightDrawerViewController:rightSideDrawerViewController];
     }
-    [self.drawerController setRestorationIdentifier:@"MMDrawer"];
     [self.drawerController setMaximumRightDrawerWidth:200.0];
     [self.drawerController setOpenDrawerGestureModeMask:MMOpenDrawerGestureModeAll];
     [self.drawerController setCloseDrawerGestureModeMask:MMCloseDrawerGestureModeAll];
@@ -77,7 +52,7 @@
              block(drawerController, drawerSide, percentVisible);
          }
      }];
-    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+
     if(OSVersionIsAtLeastiOS7()){
         UIColor * tintColor = [UIColor colorWithRed:29.0/255.0
                                               green:173.0/255.0
@@ -85,7 +60,6 @@
                                               alpha:1.0];
         [self.window setTintColor:tintColor];
     }
-    [self.window setRootViewController:self.drawerController];
 
     return YES;
 }
@@ -94,7 +68,6 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     self.window.backgroundColor = [UIColor whiteColor];
-    [self.window makeKeyAndVisible];
     
     return YES;
 }

--- a/KitchenSink/ExampleFiles/MMDrawerControllerKitchenSink-Info.plist
+++ b/KitchenSink/ExampleFiles/MMDrawerControllerKitchenSink-Info.plist
@@ -31,14 +31,16 @@
 	<string>1.0.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMainNibFile</key>
+	<string>MainController</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/KitchenSink/ExampleFiles/MainController.xib
+++ b/KitchenSink/ExampleFiles/MainController.xib
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="14A329f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment defaultVersion="1536" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UIApplication">
+            <connections>
+                <outlet property="delegate" destination="bYg-Ix-Cfg" id="h4M-LL-qlT"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <customObject id="bYg-Ix-Cfg" customClass="MMAppDelegate">
+            <connections>
+                <outlet property="drawerController" destination="xop-6H-Xm8" id="YUR-AK-04K"/>
+                <outlet property="window" destination="Na2-4i-xf1" id="9eH-KO-qFj"/>
+            </connections>
+        </customObject>
+        <window opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="Na2-4i-xf1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <connections>
+                <outlet property="rootViewController" destination="xop-6H-Xm8" id="uMm-Tg-fm1"/>
+            </connections>
+        </window>
+        <viewController restorationIdentifier="MMDrawer" id="xop-6H-Xm8" customClass="MMDrawerController">
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <connections>
+                <outlet property="centerViewController" destination="JI8-Vv-AEG" id="szD-XS-r83"/>
+                <outlet property="leftDrawerViewController" destination="0DC-Dx-jZc" id="wB2-QO-Ewa"/>
+                <outlet property="rightDrawerViewController" destination="RhC-no-4sf" id="CJG-i1-6R7"/>
+            </connections>
+        </viewController>
+        <navigationController restorationIdentifier="MMExampleLeftNavigationControllerRestorationKey" definesPresentationContext="YES" id="0DC-Dx-jZc" customClass="MMNavigationController">
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <navigationBar key="navigationBar" contentMode="scaleToFill" id="Ody-eS-sJP">
+                <autoresizingMask key="autoresizingMask"/>
+            </navigationBar>
+            <viewControllers>
+                <viewController restorationIdentifier="MMExampleLeftSideDrawerController" id="MqV-YQ-SC5" customClass="MMExampleLeftSideDrawerViewController">
+                    <navigationItem key="navigationItem" title="Item" id="1b9-SZ-wzV"/>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+                </viewController>
+            </viewControllers>
+        </navigationController>
+        <navigationController restorationIdentifier="MMExampleCenterNavigationControllerRestorationKey" definesPresentationContext="YES" id="JI8-Vv-AEG" customClass="MMNavigationController">
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <navigationBar key="navigationBar" contentMode="scaleToFill" id="Ni8-6f-R1y">
+                <autoresizingMask key="autoresizingMask"/>
+            </navigationBar>
+            <viewControllers>
+                <viewController restorationIdentifier="MMExampleCenterControllerRestorationKey" id="gMh-B2-6uZ" customClass="MMExampleCenterTableViewController">
+                    <navigationItem key="navigationItem" title="Item" id="H47-Q7-6Ag"/>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+                </viewController>
+            </viewControllers>
+        </navigationController>
+        <navigationController restorationIdentifier="MMExampleRightNavigationControllerRestorationKey" definesPresentationContext="YES" id="RhC-no-4sf" customClass="MMNavigationController">
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+            <navigationBar key="navigationBar" contentMode="scaleToFill" id="w5F-5L-VAH">
+                <autoresizingMask key="autoresizingMask"/>
+            </navigationBar>
+            <viewControllers>
+                <viewController restorationIdentifier="MMExampleRightSideDrawerController" id="sFr-nm-hud" customClass="MMExampleRightSideDrawerViewController">
+                    <navigationItem key="navigationItem" title="Item" id="mkJ-Dy-8M6"/>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <simulatedOrientationMetrics key="simulatedOrientationMetrics"/>
+                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+                </viewController>
+            </viewControllers>
+        </navigationController>
+    </objects>
+</document>

--- a/KitchenSink/ExampleFiles/main.m
+++ b/KitchenSink/ExampleFiles/main.m
@@ -26,6 +26,6 @@
 int main(int argc, char *argv[])
 {
     @autoreleasepool {
-        return UIApplicationMain(argc, argv, nil, NSStringFromClass([MMAppDelegate class]));
+        return UIApplicationMain(argc, argv, nil, nil);
     }
 }

--- a/KitchenSink/MMDrawerControllerKitchenSink.xcodeproj/project.pbxproj
+++ b/KitchenSink/MMDrawerControllerKitchenSink.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		29EEA51B17998320006D68B7 /* MMNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 29EEA51A17998320006D68B7 /* MMNavigationController.m */; };
 		29EEA51E1799923E006D68B7 /* MMExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 29EEA51D1799923E006D68B7 /* MMExampleViewController.m */; };
 		29F6163B172AC22A00B31282 /* MMDrawerBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 29F6163A172AC22A00B31282 /* MMDrawerBarButtonItem.m */; };
+		E5E624E819A6DCA500E1FBBA /* MainController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E5E624E719A6DCA400E1FBBA /* MainController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -91,6 +92,7 @@
 		29F61639172AC22A00B31282 /* MMDrawerBarButtonItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MMDrawerBarButtonItem.h; sourceTree = "<group>"; };
 		29F6163A172AC22A00B31282 /* MMDrawerBarButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMDrawerBarButtonItem.m; sourceTree = "<group>"; };
 		462C592D1757C16B006C1D6F /* MMDrawerController+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MMDrawerController+Subclass.h"; sourceTree = "<group>"; };
+		E5E624E719A6DCA400E1FBBA /* MainController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainController.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +144,7 @@
 			children = (
 				294A1D1F17199537005BF6B1 /* MMAppDelegate.h */,
 				294A1D2017199537005BF6B1 /* MMAppDelegate.m */,
+				E5E624E719A6DCA400E1FBBA /* MainController.xib */,
 				2961190E173845FD00CD4063 /* VisualStateManager */,
 				2961190D173845EF00CD4063 /* CustomViews */,
 				2961190C173845E000CD4063 /* ViewControllers */,
@@ -303,6 +306,7 @@
 				294A1D2517199537005BF6B1 /* Default@2x.png in Resources */,
 				294A1D2717199537005BF6B1 /* Default-568h@2x.png in Resources */,
 				29E2C6181738A10F00606309 /* Icon-72.png in Resources */,
+				E5E624E819A6DCA500E1FBBA /* MainController.xib in Resources */,
 				29E2C6191738A10F00606309 /* Icon-72@2x.png in Resources */,
 				29E2C61A1738A10F00606309 /* Icon.png in Resources */,
 				29E2C61B1738A10F00606309 /* Icon@2x.png in Resources */,

--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -106,21 +106,21 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  
  This can only be set via the init methods, as well as the `setNewCenterViewController:...` methods. The size of this view controller will automatically be set to the size of the drawer container view controller, and it's position is modified from within this class. Do not modify the frame externally.
  */
-@property (nonatomic, strong) UIViewController * centerViewController;
+@property (nonatomic, strong) IBOutlet UIViewController * centerViewController;
 
 /**
  The left drawer view controller. 
  
  The size of this view controller is managed within this class, and is automatically set to the appropriate size based on the `maximumLeftDrawerWidth`. Do not modify the frame externally.
  */
-@property (nonatomic, strong) UIViewController * leftDrawerViewController;
+@property (nonatomic, strong) IBOutlet UIViewController * leftDrawerViewController;
 
 /**
  The right drawer view controller. 
  
  The size of this view controller is managed within this class, and is automatically set to the appropriate size based on the `maximumRightDrawerWidth`. Do not modify the frame externally.
  */
-@property (nonatomic, strong) UIViewController * rightDrawerViewController;
+@property (nonatomic, strong) IBOutlet UIViewController * rightDrawerViewController;
 
 /**
  The maximum width of the `leftDrawerViewController`. 
@@ -266,6 +266,20 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
 -(void)toggleDrawerSide:(MMDrawerSide)drawerSide animated:(BOOL)animated completion:(void(^)(BOOL finished))completion;
 
 /**
+ Toggle the left drawer open/closed.
+ 
+ @param sender The sender object.
+ */
+-(IBAction)toggleLeftDrawer:(id)sender;
+
+/**
+ Toggle the right drawer open/closed.
+ 
+ @param sender The sender object.
+ */
+-(IBAction)toggleRightDrawer:(id)sender;
+
+/**
  Closes the open drawer.
  
  @param animated Determines whether the drawer side should be closed animated
@@ -273,6 +287,13 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  
  */
 -(void)closeDrawerAnimated:(BOOL)animated completion:(void(^)(BOOL finished))completion;
+
+/**
+ Close the open drawer.
+ 
+ @param sender The sender object.
+ */
+-(IBAction)closeDrawer:(id)sender;
 
 /**
  Opens the `drawer` passed in.
@@ -283,6 +304,20 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  
  */
 -(void)openDrawerSide:(MMDrawerSide)drawerSide animated:(BOOL)animated completion:(void(^)(BOOL finished))completion;
+
+/**
+ Opens the left drawer.
+ 
+ @param sender The sender object.
+ */
+-(IBAction)openLeftDrawer:(id)sender;
+
+/**
+ Opens the right drawer.
+ 
+ @param sender The sender object.
+ */
+-(IBAction)openRightDrawer:(id)sender;
 
 ///---------------------------------------
 /// @name Setting a new Center View Controller

--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -227,7 +227,7 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  
  @return The newly-initialized drawer container view controller.
  */
--(id)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController;
+-(instancetype)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController;
 
 /**
  Creates and initializes an `MMDrawerController` object with the specified center view controller, left drawer view controller.
@@ -237,7 +237,7 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  
  @return The newly-initialized drawer container view controller.
  */
--(id)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController;
+-(instancetype)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController;
 
 /**
  Creates and initializes an `MMDrawerController` object with the specified center view controller, right drawer view controller.
@@ -247,7 +247,7 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  
  @return The newly-initialized drawer container view controller.
  */
--(id)initWithCenterViewController:(UIViewController *)centerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController;
+-(instancetype)initWithCenterViewController:(UIViewController *)centerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController;
 
 ///---------------------------------------
 /// @name Opening and Closing a Drawer

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -160,7 +160,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 	return self;
 }
 
--(id)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
+-(instancetype)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
     NSParameterAssert(centerViewController);
     self = [super init];
     if(self){
@@ -171,11 +171,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     return self;
 }
 
--(id)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController{
+-(instancetype)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController{
     return [self initWithCenterViewController:centerViewController leftDrawerViewController:leftDrawerViewController rightDrawerViewController:nil];
 }
 
--(id)initWithCenterViewController:(UIViewController *)centerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
+-(instancetype)initWithCenterViewController:(UIViewController *)centerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
     return [self initWithCenterViewController:centerViewController leftDrawerViewController:nil rightDrawerViewController:rightDrawerViewController];
 }
 

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -252,8 +252,20 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     }
 }
 
+-(IBAction)toggleLeftDrawer:(id)sender{
+    [self toggleDrawerSide:MMDrawerSideLeft animated:YES completion:NULL];
+}
+
+-(IBAction)toggleRightDrawer:(id)sender{
+    [self toggleDrawerSide:MMDrawerSideRight animated:YES completion:NULL];
+}
+
 -(void)closeDrawerAnimated:(BOOL)animated completion:(void (^)(BOOL finished))completion{
     [self closeDrawerAnimated:animated velocity:self.animationVelocity animationOptions:UIViewAnimationOptionCurveEaseInOut completion:completion];
+}
+
+-(IBAction)closeDrawer:(id)sender{
+    [self closeDrawerAnimated:YES completion:NULL];
 }
 
 -(void)closeDrawerAnimated:(BOOL)animated velocity:(CGFloat)velocity animationOptions:(UIViewAnimationOptions)options completion:(void (^)(BOOL finished))completion{
@@ -317,6 +329,14 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     NSParameterAssert(drawerSide != MMDrawerSideNone);
     
     [self openDrawerSide:drawerSide animated:animated velocity:self.animationVelocity animationOptions:UIViewAnimationOptionCurveEaseInOut completion:completion];
+}
+
+-(IBAction)openLeftDrawer:(id)sender{
+    [self openDrawerSide:MMDrawerSideLeft animated:YES completion:NULL];
+}
+
+-(IBAction)openRightDrawer:(id)sender{
+    [self openDrawerSide:MMDrawerSideRight animated:YES completion:NULL];
 }
 
 -(void)openDrawerSide:(MMDrawerSide)drawerSide animated:(BOOL)animated velocity:(CGFloat)velocity animationOptions:(UIViewAnimationOptions)options completion:(void (^)(BOOL finished))completion{


### PR DESCRIPTION
Make the controller Interface Builder-friendly:

* Make properties `IBOutlets`.
* Add `IBActions` to toggle, open and close drawers (can be called using the first responder!).

Besides return `instancetype` instead of `id` from init methods ("new" best practice).