### PR TITLE
Add ability to configure shadowRadius, shadowOpacity, and shadowColor

### DIFF
--- a/KitchenSink/ExampleFiles/MMExampleSideDrawerViewController.m
+++ b/KitchenSink/ExampleFiles/MMExampleSideDrawerViewController.m
@@ -130,7 +130,7 @@
         case MMDrawerSectionDrawerWidth:
             return self.drawerWidths.count;
         case MMDrawerSectionShadowToggle:
-            return 1;
+            return 7;
         case MMDrawerSectionOpenDrawerGestures:
             return 3;
         case MMDrawerSectionCloseDrawerGestures:
@@ -170,11 +170,60 @@
             break;
         }
         case MMDrawerSectionShadowToggle:{
-            [cell.textLabel setText:@"Show Shadow"];
-            if(self.mm_drawerController.showsShadow)
-                [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
-            else
-                [cell setAccessoryType:UITableViewCellAccessoryNone];
+            switch (indexPath.row) {
+                case 0:
+                    [cell.textLabel setText:@"Show Shadow"];
+                    if(self.mm_drawerController.showsShadow)
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                case 1:
+                    [cell.textLabel setText:@"Shadow Radius 10"];
+                    if(self.mm_drawerController.showsShadow && (fabsf(self.mm_drawerController.shadowRadius - 10.0) <= 0.001))
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                case 2:
+                    [cell.textLabel setText:@"Shadow Radius 5"];
+                    if(self.mm_drawerController.showsShadow && fabsf(self.mm_drawerController.shadowRadius - 5.0) <= 0.001)
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                case 3:
+                    [cell.textLabel setText:@"Shadow Opacity 0.8"];
+                    if(self.mm_drawerController.showsShadow && fabsf(self.mm_drawerController.shadowOpacity - 0.8) <= 0.001)
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                case 4:
+                    [cell.textLabel setText:@"Shadow Opacity 0.4"];
+                    if(self.mm_drawerController.showsShadow && fabsf(self.mm_drawerController.shadowOpacity - 0.4) <= 0.001)
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                case 5:
+                    [cell.textLabel setText:@"Shadow Color Black"];
+                    if(self.mm_drawerController.showsShadow && self.mm_drawerController.shadowColor == [UIColor blackColor].CGColor)
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                case 6:
+                    [cell.textLabel setText:@"Shadow Color Gray"];
+                    if(self.mm_drawerController.showsShadow && self.mm_drawerController.shadowColor == [UIColor darkGrayColor].CGColor)
+                        [cell setAccessoryType:UITableViewCellAccessoryCheckmark];
+                    else
+                        [cell setAccessoryType:UITableViewCellAccessoryNone];
+                    break;
+                    
+                default:
+                    break;
+            }
             break;
         }
         case MMDrawerSectionOpenDrawerGestures:{
@@ -380,8 +429,45 @@
             break;
         }
         case MMDrawerSectionShadowToggle:{
-            [self.mm_drawerController setShowsShadow:!self.mm_drawerController.showsShadow];
-            [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+            switch (indexPath.row) {
+                case 0:
+                    [self.mm_drawerController setShowsShadow:!self.mm_drawerController.showsShadow];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                case 1:
+                    [self.mm_drawerController setShowsShadow:YES];
+                    [self.mm_drawerController setShadowRadius:10.0];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                case 2:
+                    [self.mm_drawerController setShowsShadow:YES];
+                    [self.mm_drawerController setShadowRadius:5.0];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                case 3:
+                    [self.mm_drawerController setShowsShadow:YES];
+                    [self.mm_drawerController setShadowOpacity:0.8];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                case 4:
+                    [self.mm_drawerController setShowsShadow:YES];
+                    [self.mm_drawerController setShadowOpacity:0.4];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                case 5:
+                    [self.mm_drawerController setShowsShadow:YES];
+                    [self.mm_drawerController setShadowColor:[UIColor blackColor].CGColor];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                case 6:
+                    [self.mm_drawerController setShowsShadow:YES];
+                    [self.mm_drawerController setShadowColor:[UIColor darkGrayColor].CGColor];
+                    [tableView reloadSections:[NSIndexSet indexSetWithIndex:indexPath.section] withRowAnimation:UITableViewRowAnimationNone];
+                    break;
+                    
+                default:
+                    break;
+            }
             break;
         }
         case MMDrawerSectionOpenDrawerGestures:{

--- a/KitchenSink/MMDrawerControllerKitchenSink.xcodeproj/project.xcworkspace/xcshareddata/MMDrawerControllerKitchenSink.xccheckout
+++ b/KitchenSink/MMDrawerControllerKitchenSink.xcodeproj/project.xcworkspace/xcshareddata/MMDrawerControllerKitchenSink.xccheckout
@@ -10,24 +10,36 @@
 	<string>MMDrawerControllerKitchenSink</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
+		<key>BF2FE30DD30E807A424B26D63A15FEB4A29593EB</key>
+		<string>https://github.com/trunkclub/MMDrawerController.git</string>
 		<key>C486FB0C-7803-4607-BCA9-799E743ECFBA</key>
 		<string>https://github.com/mutualmobile/MMDrawerController.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>KitchenSink/MMDrawerControllerKitchenSink.xcodeproj/project.xcworkspace</string>
+	<string>KitchenSink/MMDrawerControllerKitchenSink.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>C486FB0C-7803-4607-BCA9-799E743ECFBA</key>
+		<key>BF2FE30DD30E807A424B26D63A15FEB4A29593EB</key>
 		<string>../../..</string>
+		<key>C486FB0C-7803-4607-BCA9-799E743ECFBA</key>
+		<string>../../../../MMDrawerController-GitHub</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/mutualmobile/MMDrawerController.git</string>
+	<string>https://github.com/trunkclub/MMDrawerController.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>C486FB0C-7803-4607-BCA9-799E743ECFBA</string>
+	<string>BF2FE30DD30E807A424B26D63A15FEB4A29593EB</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>BF2FE30DD30E807A424B26D63A15FEB4A29593EB</string>
+			<key>IDESourceControlWCCName</key>
+			<string>MMDrawerController</string>
+		</dict>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>

--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -201,6 +201,27 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
 @property (nonatomic, assign) BOOL showsShadow;
 
 /**
+ The radius of the shadow drawn off of 'centerViewController` when a drawer is open.
+ 
+ By default, this is set to 10.
+ */
+@property (nonatomic, assign) CGFloat shadowRadius;
+
+/**
+ The opacity of the shadow drawn off of 'centerViewController` when a drawer is open.
+ 
+ By default, this is set to 0.8.
+ */
+@property (nonatomic, assign) CGFloat shadowOpacity;
+
+/**
+ The color of the shadow drawn off of 'centerViewController` when a drawer is open.
+ 
+ By default, this is set to the systme default (opaque black).
+ */
+@property (nonatomic, assign) CGColorRef shadowColor;
+
+/**
  The flag determining if a custom background view should appear beneath the status bar, forcing the child content to be drawn lower than the status bar. This property is only available for > iOS 7.0 to take into account for the new behavior of the status bar.
  
  By default, this is set to NO. If running on < iOS 7.0, it will always return NO.

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -34,9 +34,6 @@ CGFloat const MMDrawerDefaultBounceDistance = 50.0f;
 NSTimeInterval const MMDrawerDefaultBounceAnimationDuration = 0.2f;
 CGFloat const MMDrawerDefaultSecondBounceDistancePercentage = .25f;
 
-CGFloat const MMDrawerDefaultShadowRadius = 10.0f;
-CGFloat const MMDrawerDefaultShadowOpacity = 0.8;
-
 NSTimeInterval const MMDrawerMinimumAnimationDuration = 0.15f;
 
 CGFloat const MMDrawerBezelRange = 20.0f;
@@ -186,6 +183,9 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [self setAnimationVelocity:MMDrawerDefaultAnimationVelocity];
     
     [self setShowsShadow:YES];
+    [self setShadowRadius:10.0f];
+    [self setShadowOpacity:0.8f];
+    [self setShadowColor:[UIColor blackColor].CGColor];
     [self setShouldStretchDrawer:YES];
     
     [self setOpenDrawerGestureModeMask:MMOpenDrawerGestureModeNone];
@@ -859,6 +859,21 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [self updateShadowForCenterView];
 }
 
+-(void)setShadowRadius:(CGFloat)shadowRadius{
+    _shadowRadius = shadowRadius;
+    [self updateShadowForCenterView];
+}
+
+-(void)setShadowOpacity:(CGFloat)shadowOpacity{
+    _shadowOpacity = shadowOpacity;
+    [self updateShadowForCenterView];
+}
+
+-(void)setShadowColor:(CGColorRef)shadowColor{
+    _shadowColor = shadowColor;
+    [self updateShadowForCenterView];
+}
+
 -(void)setOpenSide:(MMDrawerSide)openSide{
     if(_openSide != openSide){
         _openSide = openSide;
@@ -1245,8 +1260,9 @@ static inline CGFloat originXForDrawerOriginAndTargetOriginOffset(CGFloat origin
     UIView * centerView = self.centerContainerView;
     if(self.showsShadow){
         centerView.layer.masksToBounds = NO;
-        centerView.layer.shadowRadius = MMDrawerDefaultShadowRadius;
-        centerView.layer.shadowOpacity = MMDrawerDefaultShadowOpacity;
+        centerView.layer.shadowRadius = self.shadowRadius;
+        centerView.layer.shadowOpacity = self.shadowOpacity;
+        centerView.layer.shadowColor = self.shadowColor;
         
         /** In the event this gets called a lot, we won't update the shadowPath
         unless it needs to be updated (like during rotation) */


### PR DESCRIPTION
This also includes an example app update to play with the configurations.

This is not the only open pull request for drawer shadow configuration. However, I didn't see one that also updates the example. We need these for our own app and I suspect other folks out there would love to see this feature addition.