### PR TITLE
Avoid duplicate headers (and the warning in XCode 6) on pod install

### DIFF
--- a/MMDrawerController.podspec
+++ b/MMDrawerController.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
                        "http://mutualmobile.github.io/MMDrawerController/ExampleImages/example2.png" ]
   
   s.subspec 'Core' do |ss|
-    ss.source_files = 'MMDrawerController/MMDrawerController*', 'MMDrawerController/UIViewController+MMDrawerController*'
+    ss.source_files = 'MMDrawerController/MMDrawerController.*', 'MMDrawerController/UIViewController+MMDrawerController*'
     ss.framework  = 'QuartzCore'
   end
   


### PR DESCRIPTION
This should solve #295 

I was able to test this by pod installing from my local copy using the `:path` parameter, and the warning goes away.