### PR TITLE
Call removeFromParentViewController after removeFromSuperview in setCent...

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -409,11 +409,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
         if(animated == NO){
             [oldCenterViewController beginAppearanceTransition:NO animated:NO];
         }
-        [oldCenterViewController removeFromParentViewController];
         [oldCenterViewController.view removeFromSuperview];
         if(animated == NO){
             [oldCenterViewController endAppearanceTransition];
         }
+        [oldCenterViewController removeFromParentViewController];
     }
     
     _centerViewController = centerViewController;


### PR DESCRIPTION
...erViewController to avoid EXC_BAD_ACCESS due to nil view value

Resolves an encountered issue with NappDrawer (https://github.com/viezel/NappDrawer/issues/139) where setting the center window would result in an app crash
