### PR TITLE
Smooth the transition if you resize the drawer while it's open (e.g. for...

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -591,9 +591,13 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
          options:UIViewAnimationOptionCurveEaseInOut
          animations:^{
              [self.centerContainerView setFrame:newCenterRect];
-             [sideDrawerViewController.view setFrame:sideDrawerViewController.mm_visibleDrawerFrame];
-         }
+             if (oldWidth < width){
+                 [sideDrawerViewController.view setFrame:sideDrawerViewController.mm_visibleDrawerFrame];
+             }         }
          completion:^(BOOL finished) {
+             if (oldWidth >= width){
+                 [sideDrawerViewController.view setFrame:sideDrawerViewController.mm_visibleDrawerFrame];
+             }
              if(completion != nil){
                  completion(finished);
              }

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -593,7 +593,8 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
              [self.centerContainerView setFrame:newCenterRect];
              if (oldWidth < width){
                  [sideDrawerViewController.view setFrame:sideDrawerViewController.mm_visibleDrawerFrame];
-             }         }
+             }
+         }
          completion:^(BOOL finished) {
              if (oldWidth >= width){
                  [sideDrawerViewController.view setFrame:sideDrawerViewController.mm_visibleDrawerFrame];


### PR DESCRIPTION
... subnav)

I'm using the drawer for a 2-tier drawer. When you open the drawer, it opens 160px wide. When you click on an option, if that option has MORE options, it opens an ADDITIONAL 160px. If you then click on a different option in the first tier that DOESNT have more options, it collapses back to 160px.

This smooths out the transition, before it would just "cut" away the 160 pixels while shrinking back.