### PR TITLE
Fix infinite, recursive init call for subclass

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -162,7 +162,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 
 -(instancetype)initWithCenterViewController:(UIViewController *)centerViewController leftDrawerViewController:(UIViewController *)leftDrawerViewController rightDrawerViewController:(UIViewController *)rightDrawerViewController{
     NSParameterAssert(centerViewController);
-    self = [self init];
+    self = [super init];
     if(self){
         [self setCenterViewController:centerViewController];
         [self setLeftDrawerViewController:leftDrawerViewController];


### PR DESCRIPTION
Fix infinite, recursive init call if a MMDrawerController subclass implements -init

This was changed in dd06fdeeeffd2a2d3140091c0e76d71f434caeb2. I cannot see the reason for this change? I'm using a subclass of MMDrawerController in my current project, and [self init] instead of [super init] causes a infinite recursive method call crash. Was it a change by mistake? Thanks!