### PR TITLE
Expose gesture recognizers publicly

### DIFF
--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -256,6 +256,16 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  */
 @property (nonatomic, assign) CGFloat panVelocityXAnimationThreshold;
 
+/**
+ The gesture recognizer used to slide the drawers open and closed.
+ */
+@property (nonatomic, strong, readonly) UIPanGestureRecognizer *drawerPanningGestureRecognizer;
+
+/**
+ The gesture recognizer used to close either drawer that is open by tapping on the center view.
+ */
+@property (nonatomic, strong, readonly) UITapGestureRecognizer *tapToCloseGestureRecognizer;
+
 ///---------------------------------------
 /// @name Initializing a `MMDrawerController`
 ///---------------------------------------

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -138,6 +138,9 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 @property (nonatomic, copy) MMDrawerGestureCompletionBlock gestureCompletion;
 @property (nonatomic, assign, getter = isAnimatingDrawer) BOOL animatingDrawer;
 
+@property (nonatomic, strong, readwrite) UIPanGestureRecognizer *drawerPanningGestureRecognizer;
+@property (nonatomic, strong, readwrite) UITapGestureRecognizer *tapToCloseGestureRecognizer;
+
 @end
 
 @implementation MMDrawerController
@@ -1269,14 +1272,26 @@ static inline CGFloat originXForDrawerOriginAndTargetOriginOffset(CGFloat origin
 }
 
 #pragma mark - Helpers
+
+-(UIPanGestureRecognizer *)drawerPanningGestureRecognizer{
+    if (!_drawerPanningGestureRecognizer) {
+        _drawerPanningGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureCallback:)];
+        _drawerPanningGestureRecognizer.delegate = self;
+    }
+    return _drawerPanningGestureRecognizer;
+}
+
+-(UITapGestureRecognizer *)tapToCloseGestureRecognizer{
+    if (!_tapToCloseGestureRecognizer) {
+        _tapToCloseGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGestureCallback:)];
+        _tapToCloseGestureRecognizer.delegate = self;
+    }
+    return _tapToCloseGestureRecognizer;
+}
+
 -(void)setupGestureRecognizers{
-    UIPanGestureRecognizer * pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureCallback:)];
-    [pan setDelegate:self];
-    [self.view addGestureRecognizer:pan];
-    
-    UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGestureCallback:)];
-    [tap setDelegate:self];
-    [self.view addGestureRecognizer:tap];
+    [self.view addGestureRecognizer:self.drawerPanningGestureRecognizer];
+    [self.view addGestureRecognizer:self.tapToCloseGestureRecognizer];
 }
 
 -(void)prepareToPresentDrawer:(MMDrawerSide)drawer animated:(BOOL)animated{

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -124,6 +124,8 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     CGFloat _maximumRightDrawerWidth;
     CGFloat _maximumLeftDrawerWidth;
     UIColor * _statusBarViewBackgroundColor;
+    UIPanGestureRecognizer * _drawerPanningGestureRecognizer;
+    UITapGestureRecognizer * _tapToCloseGestureRecognizer;
 }
 
 @property (nonatomic, assign, readwrite) MMDrawerSide openSide;
@@ -137,9 +139,6 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
 @property (nonatomic, copy) MMDrawerGestureShouldRecognizeTouchBlock gestureShouldRecognizeTouch;
 @property (nonatomic, copy) MMDrawerGestureCompletionBlock gestureCompletion;
 @property (nonatomic, assign, getter = isAnimatingDrawer) BOOL animatingDrawer;
-
-@property (nonatomic, strong, readwrite) UIPanGestureRecognizer *drawerPanningGestureRecognizer;
-@property (nonatomic, strong, readwrite) UITapGestureRecognizer *tapToCloseGestureRecognizer;
 
 @end
 


### PR DESCRIPTION
I need to be able to coordinate interactions between the gesture recognizers used in MMDrawerController and elsewhere, and in order to do that the ones MMDrawerController uses need to be publicly accessible. This should make sure that the recognizer is always created when accessed, and is added to the view when necessary
