### PR TITLE
Fix unresponsive UIPanGestureRecognizer after pan gesture

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -1056,6 +1056,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
         case UIGestureRecognizerStateBegan:{
             if(self.animatingDrawer){
                 [panGesture setEnabled:NO];
+                [panGesture setEnabled:YES];
                 break;
             }
             else {


### PR DESCRIPTION
...while drawer animation is in progress

Cancel current gesture:

``` objective-c
[panGesture setEnabled:NO];
[panGesture setEnabled:YES];
```
