### PR TITLE
[FIX] Center view container wrong y position during transition

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -1103,7 +1103,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
             
             newFrame = self.centerContainerView.frame;
             newFrame.origin.x = floor(newFrame.origin.x);
-            newFrame.origin.y = floor(newFrame.origin.y);
+            newFrame.origin.y = self.startingPanRect.origin.y;
             self.centerContainerView.frame = newFrame;
             
             break;


### PR DESCRIPTION
...from center with extended status bar to side with hidden status bar

There is a 10 pt gap below center controller, when you start panning from center controller with higher status bar (in-call) to side with hidden status bar, because of change of available screen space and cached values `self.startingPanRect` there is position compensation on `y` after centering center view. 

Apply `y` position value from `self.startingPanRect` to final frame of center view.
