### PR TITLE
Prevents graphical glitch when tapping to open hamburger menu

### DIFF
--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -360,6 +360,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
             CGFloat distance = ABS(CGRectGetMinX(oldFrame)-newFrame.origin.x);
             NSTimeInterval duration = MAX(distance/ABS(velocity),MMDrawerMinimumAnimationDuration);
             
+            //Prepares the controller for appearance transistion:
+            if(drawerSide != self.openSide){
+                [sideDrawerViewController endAppearanceTransition];
+            }
+            
             [UIView
              animateWithDuration:(animated?duration:0.0)
              delay:0.0


### PR DESCRIPTION
I found a graphical glitch when adding a custom gesture (touch up) to open the left drawer controller:  the left drawer controller's scroll view began slightly scrolled up, which would snap to the correct position after the drawer opening animation would complete. I solved this by simply preparing the left drawer controller for animation by making sure that it was in the correct position.  Thanks!
