### PR TITLE
add centerContainerViewBackgroundColor property

### DIFF
--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -214,6 +214,13 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
  */
 @property (nonatomic, strong) UIColor * statusBarViewBackgroundColor;
 
+
+/**
+ The color of the container view's background
+ By default, this is set `[UIColor clearColor]`.
+ **/
+@property (nonatomic, strong) UIColor *centerContainerViewBackgroundColor;
+
 ///---------------------------------------
 /// @name Initializing a `MMDrawerController`
 ///---------------------------------------

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -121,6 +121,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     CGFloat _maximumRightDrawerWidth;
     CGFloat _maximumLeftDrawerWidth;
     UIColor * _statusBarViewBackgroundColor;
+    UIColor * _centerContainerViewBackgroundColor;
 }
 
 @property (nonatomic, assign, readwrite) MMDrawerSide openSide;
@@ -379,7 +380,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     if(_centerContainerView == nil){
         _centerContainerView = [[MMDrawerCenterContainerView alloc] initWithFrame:self.childControllerContainerView.bounds];
         [self.centerContainerView setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight];
-        [self.centerContainerView setBackgroundColor:[UIColor clearColor]];
+        [self.centerContainerView setBackgroundColor:self.centerContainerViewBackgroundColor];
         [self.centerContainerView setOpenSide:self.openSide];
         [self.centerContainerView setCenterInteractionMode:self.centerHiddenInteractionMode];
         [self.childControllerContainerView addSubview:self.centerContainerView];
@@ -837,6 +838,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [self.dummyStatusBarView setBackgroundColor:_statusBarViewBackgroundColor];
 }
 
+-(void)setCenterContainerViewBackgroundColor:(UIColor *)centerContainerViewBackgroundColor{
+    _centerContainerViewBackgroundColor = centerContainerViewBackgroundColor;
+    [self.centerContainerView setBackgroundColor:centerContainerViewBackgroundColor];
+}
+
 #pragma mark - Getters
 -(CGFloat)maximumLeftDrawerWidth{
     if(self.leftDrawerViewController){
@@ -895,6 +901,13 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
         _statusBarViewBackgroundColor = [UIColor blackColor];
     }
     return _statusBarViewBackgroundColor;
+}
+
+- (UIColor*)centerContainerViewBackgroundColor {
+    if (_centerContainerViewBackgroundColor == nil) {
+        _centerContainerViewBackgroundColor = [UIColor clearColor];
+    }
+    return _centerContainerViewBackgroundColor;
 }
 
 #pragma mark - Gesture Handlers


### PR DESCRIPTION
The purpose of this code is to set the colour behind the status bar
when showing a search display controller in the centerViewController to
make the background color matches the centerViewController rather than
being clearColor.
