### PR TITLE
Add centerContainerViewBackgroundColor property

### DIFF
--- a/MMDrawerController/MMDrawerController.h
+++ b/MMDrawerController/MMDrawerController.h
@@ -243,6 +243,12 @@ typedef void (^MMDrawerControllerDrawerVisualStateBlock)(MMDrawerController * dr
 @property (nonatomic, strong) UIColor * statusBarViewBackgroundColor;
 
 /**
+ The color of the center container view's background
+ By default, this is set `[UIColor clearColor]`.
+ **/
+@property (nonatomic, strong) UIColor *centerContainerViewBackgroundColor;
+
+/**
  The value determining panning range of centerView's bezel if the user can open drawer with 'MMOpenDrawerGestureModeBezelPanningCenterView' or close drawer with 'MMCloseDrawerGestureModeBezelPanningCenterView' .
  
  By default, this is set 20.0f.

--- a/MMDrawerController/MMDrawerController.m
+++ b/MMDrawerController/MMDrawerController.m
@@ -124,6 +124,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     CGFloat _maximumRightDrawerWidth;
     CGFloat _maximumLeftDrawerWidth;
     UIColor * _statusBarViewBackgroundColor;
+    UIColor * _centerContainerViewBackgroundColor;
 }
 
 @property (nonatomic, assign, readwrite) MMDrawerSide openSide;
@@ -408,7 +409,7 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     if(_centerContainerView == nil){
         _centerContainerView = [[MMDrawerCenterContainerView alloc] initWithFrame:centerFrame];
         [self.centerContainerView setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight];
-        [self.centerContainerView setBackgroundColor:[UIColor clearColor]];
+        [self.centerContainerView setBackgroundColor:self.centerContainerViewBackgroundColor];
         [self.centerContainerView setOpenSide:self.openSide];
         [self.centerContainerView setCenterInteractionMode:self.centerHiddenInteractionMode];
         [self.childControllerContainerView addSubview:self.centerContainerView];
@@ -962,6 +963,11 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     [self.dummyStatusBarView setBackgroundColor:_statusBarViewBackgroundColor];
 }
 
+-(void)setCenterContainerViewBackgroundColor:(UIColor *)centerContainerViewBackgroundColor{
+    _centerContainerViewBackgroundColor = centerContainerViewBackgroundColor;
+    [self.centerContainerView setBackgroundColor:centerContainerViewBackgroundColor];
+}
+
 -(void)setAnimatingDrawer:(BOOL)animatingDrawer{
     _animatingDrawer = animatingDrawer;
     [self.view setUserInteractionEnabled:!animatingDrawer];
@@ -1037,6 +1043,14 @@ static NSString *MMDrawerOpenSideKey = @"MMDrawerOpenSide";
     }
     return _statusBarViewBackgroundColor;
 }
+
+- (UIColor*)centerContainerViewBackgroundColor {
+    if (_centerContainerViewBackgroundColor == nil) {
+        _centerContainerViewBackgroundColor = [UIColor clearColor];
+    }
+    return _centerContainerViewBackgroundColor;
+}
+
 
 #pragma mark - Gesture Handlers
 


### PR DESCRIPTION
The purpose of this code is to set the background colour behind the status bar because when I  put a search display controller on the center-viewcontroller, the background color of the centerContainerView is exposed behind the status bar. So, I would like to set the backgroundColor of the centerContainerView to match the center-viewcontroller.
