### PR TITLE
Update pod version on installing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Official appledoc documentation can be found at [CocoaDocs](http://cocoadocs.org
 You can install MMDrawerController in your project by using [CocoaPods](https://github.com/cocoapods/cocoapods):
 
 ```Ruby
-pod 'MMDrawerController', '~> 0.5.7'
+pod 'MMDrawerController', '~> 0.6.0'
 ```
 
 ---


### PR DESCRIPTION
The pod version on the installing instructions is outdated since the latest release (at least on GitHub release page) is v0.6.0
